### PR TITLE
add base64encode and base64decode template functions for transforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 data/
 config.yaml
 devcerts/
+.idea/

--- a/README.md
+++ b/README.md
@@ -223,6 +223,40 @@ Apply a Go template to the secret data. The template will be passed the secret o
       {{ .simple_string_data }}
 ```
 
+Template transforms use Go's `text/template` syntax and include the following helper functions:
+
+| Function       | Description                                                                                                                    |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `json`         | Marshals a value to JSON. Useful for safely rendering strings, objects, arrays, and values containing JSON-special characters. |
+| `string`       | Converts a value to a string using Go string formatting.                                                                       |
+| `int`          | Converts a value to an int.                                                                                                    |
+| `base64encode` | Base64-encodes a string value.                                                                                                 |
+| `base64decode` | Base64-decodes a string value.                                                                                                 |
+
+##### JSON escaping
+
+When producing JSON output, values containing quotes, backslashes, newlines, or other JSON-special characters should be escaped with the `json` helper.
+```yaml
+  transforms:
+    template: |
+      {
+        "cannot_handle_json_chars_in_password": "{{ .password }}", ⚠️
+        "safely_escaped_password": {{ .password | json }}          ✅
+      }
+```
+
+##### Base64 encoding / decoding
+Base64 encoding and decoding can be performed with the `base64encode` and `base64decode` helpers.
+Especially after decoding, it's suggested to escape JSON-special characters with the `json` helper.
+```yaml
+  transforms:
+    template: |
+      {
+        "base64encoded": {{ .password | base64encode | json }},
+        "base64decoded": {{ .base64encoded | base64decode | json }}
+      }
+```
+
 ### Destination Configuration
 
 While the Secret Driver is technically a generic interface, currently, the service implements a one-way secret sync from the source to the destination, where only `vault` type data stores are supported as the source. The destination can be any of the supported secret stores. This is by design, to ensure that the source of truth is always Vault.

--- a/internal/transforms/transform.go
+++ b/internal/transforms/transform.go
@@ -2,6 +2,7 @@ package transforms
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -16,13 +17,13 @@ func ExecuteTransformTemplate(sc v1alpha1.VaultSecretSync, secret []byte) ([]byt
 		return secret, nil
 	}
 	t, err := template.New("transform").Funcs(template.FuncMap{
-		"json": func(v interface{}) string {
+		"json": func(v interface{}) (string, error) {
 			// Convert the value to JSON for more complex structures
-			bytes, err := json.Marshal(v)
+			jsonBytes, err := json.Marshal(v)
 			if err != nil {
-				return ""
+				return "", err
 			}
-			return string(bytes)
+			return string(jsonBytes), nil
 		},
 		"string": func(v interface{}) string {
 			// Convert the value to a string
@@ -31,6 +32,24 @@ func ExecuteTransformTemplate(sc v1alpha1.VaultSecretSync, secret []byte) ([]byt
 		"int": func(v interface{}) int {
 			// Convert the value to an int
 			return v.(int)
+		},
+		"base64encode": func(v any) (string, error) {
+			s, ok := v.(string)
+			if !ok {
+				return "", fmt.Errorf("base64encode expects string, got %T", v)
+			}
+			return base64.StdEncoding.EncodeToString([]byte(s)), nil
+		},
+		"base64decode": func(v any) (string, error) {
+			s, ok := v.(string)
+			if !ok {
+				return "", fmt.Errorf("base64decode expects string, got %T", v)
+			}
+			data, err := base64.StdEncoding.DecodeString(s)
+			if err != nil {
+				return "", err
+			}
+			return string(data), nil
 		},
 	}).Parse(strings.TrimSpace(*sc.Spec.Transforms.Template))
 	if err != nil {

--- a/internal/transforms/transform_test.go
+++ b/internal/transforms/transform_test.go
@@ -9,11 +9,12 @@ import (
 
 func TestExecuteTransformTemplate(t *testing.T) {
 	tests := []struct {
-		name     string
-		sc       v1alpha1.VaultSecretSync
-		secret   []byte
-		expected []byte
-		wantErr  bool
+		name        string
+		sc          v1alpha1.VaultSecretSync
+		secret      []byte
+		expected    []byte
+		wantErr     bool
+		errContains string
 	}{
 		{
 			name: "No template",
@@ -27,16 +28,201 @@ func TestExecuteTransformTemplate(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name: "Valid template",
-			sc: v1alpha1.VaultSecretSync{
-				Spec: v1alpha1.VaultSecretSyncSpec{
-					Transforms: &v1alpha1.TransformSpec{
-						Template: ptrToString(`{"newKey":"{{ .key }}"}`),
-					},
-				},
-			},
+			name:     "Valid template",
+			sc:       vaultSecretSyncWithTemplate(`{"newKey":"{{ .key }}"}`),
 			secret:   []byte(`{"key":"value"}`),
 			expected: []byte(`{"newKey":"value"}`),
+			wantErr:  false,
+		},
+		{
+			// this behavior could be changed by setting `.Option("missingkey=error")` on the template
+			name:     "⚠️ requesting unknown key leads to '<no value>' value",
+			sc:       vaultSecretSyncWithTemplate(`{"newKey":"{{ .unknownKey }}"}`),
+			secret:   []byte(`{"key":"value"}`),
+			expected: []byte(`{"newKey":"<no value>"}`),
+			wantErr:  false,
+		},
+		{
+			name:        "⚠️ int function cannot handle ints (42 unmarshals to float64)",
+			sc:          vaultSecretSyncWithTemplate(`{"newKey":{{ .key | int }}}`),
+			secret:      []byte(`{"key":42}`),
+			expected:    []byte(`{"key":42}`),
+			wantErr:     true,
+			errContains: "interface conversion: interface {} is float64, not int",
+		},
+		{
+			name:        "⚠️ int function cannot handle floats",
+			sc:          vaultSecretSyncWithTemplate(`{"newKey":{{ .key | int }}}`),
+			secret:      []byte(`{"key":42.0}`),
+			expected:    []byte(`{"key":42.0}`),
+			wantErr:     true,
+			errContains: "interface conversion: interface {} is float64, not int",
+		},
+		{
+			name:        "⚠️ int function cannot handle int strings",
+			sc:          vaultSecretSyncWithTemplate(`{"newKey":{{ .key | int }}}`),
+			secret:      []byte(`{"key":"42"}`),
+			expected:    []byte(`{"key":"42"}`),
+			wantErr:     true,
+			errContains: "interface conversion: interface {} is string, not int",
+		},
+		{
+			name:        "⚠️ int function cannot handle float strings",
+			sc:          vaultSecretSyncWithTemplate(`{"newKey":{{ .key | int }}}`),
+			secret:      []byte(`{"key":"42.0"}`),
+			expected:    []byte(`{"key":"42.0"}`),
+			wantErr:     true,
+			errContains: "interface conversion: interface {} is string, not int",
+		},
+		{
+			name:     "Nested object",
+			sc:       vaultSecretSyncWithTemplate(`{"newKey":"{{ .key.foo }}"}`),
+			secret:   []byte(`{"key":{"foo":"bar"}}`),
+			expected: []byte(`{"newKey":"bar"}`),
+			wantErr:  false,
+		},
+		{
+			name:        "Invalid template returns error and original secret",
+			sc:          vaultSecretSyncWithTemplate(`{"newKey":"{{ .key "}`),
+			secret:      []byte(`{"key":"value"}`),
+			expected:    []byte(`{"key":"value"}`),
+			wantErr:     true,
+			errContains: "unterminated quoted string",
+		},
+		{
+			name:     "Escape json chars",
+			sc:       vaultSecretSyncWithTemplate(`{"field":{{ .field | json }}}`),
+			secret:   []byte(`{"field":"foo\"bar"}`),
+			expected: []byte(`{"field":"foo\"bar"}`),
+			wantErr:  false,
+		},
+		{
+			name:     "Escape password with json chars",
+			sc:       vaultSecretSyncWithTemplate(`{"field":{{ .field | json }}}`),
+			secret:   []byte(`{"field":"password with special chars \"§$%?\\/()="}`),
+			expected: []byte(`{"field":"password with special chars \"§$%?\\/()="}`),
+			wantErr:  false,
+		},
+		{
+			name:     "⚠️ unescaped password with json chars creates invalid json",
+			sc:       vaultSecretSyncWithTemplate(`{"field":"{{ .field }}"}`),
+			secret:   []byte(`{"field":"password with special chars \"§$%?\\/()="}`),
+			expected: []byte(`{"field":"password with special chars "§$%?\/()="}`),
+			wantErr:  false,
+		},
+		{
+			name:     "Templates can produce invalid json",
+			sc:       vaultSecretSyncWithTemplate(`{"field":"{{ .field }}"}`),
+			secret:   []byte(`{"field":"foo\"bar"}`),
+			expected: []byte(`{"field":"foo"bar"}`),
+			wantErr:  false,
+		},
+		{
+			name:     "String function converts number",
+			sc:       vaultSecretSyncWithTemplate(`{"count":"{{ .count | string }}"}`),
+			secret:   []byte(`{"count":3}`),
+			expected: []byte(`{"count":"3"}`),
+			wantErr:  false,
+		},
+		{
+			name:     "String function on string",
+			sc:       vaultSecretSyncWithTemplate(`{"count":"{{ .count | string }}"}`),
+			secret:   []byte(`{"count":"3"}`),
+			expected: []byte(`{"count":"3"}`),
+			wantErr:  false,
+		},
+		{
+			name:     "base64encode on string",
+			sc:       vaultSecretSyncWithTemplate(`{"field":"{{ .field | base64encode }}"}`),
+			secret:   []byte(`{"field":"foobar"}`),
+			expected: []byte(`{"field":"Zm9vYmFy"}`),
+			wantErr:  false,
+		},
+		{
+			name:     "base64encode on empty string",
+			sc:       vaultSecretSyncWithTemplate(`{"field":"{{ .field | base64encode }}"}`),
+			secret:   []byte(`{"field":""}`),
+			expected: []byte(`{"field":""}`),
+			wantErr:  false,
+		},
+		{
+			name:     "base64encode handles unicode string",
+			sc:       vaultSecretSyncWithTemplate(`{"field":"{{ .field | base64encode }}"}`),
+			secret:   []byte(`{"field":"こんにちは"}`),
+			expected: []byte(`{"field":"44GT44KT44Gr44Gh44Gv"}`),
+			wantErr:  false,
+		},
+		{
+			name:        "base64encode on number returns error",
+			sc:          vaultSecretSyncWithTemplate(`{"field":"{{ .field | base64encode }}"}`),
+			secret:      []byte(`{"field":42}`),
+			expected:    []byte(`{"field":42}`),
+			wantErr:     true,
+			errContains: "base64encode expects string",
+		},
+		{
+			name:     "base64decode on string",
+			sc:       vaultSecretSyncWithTemplate(`{"field":"{{ .field | base64decode }}"}`),
+			secret:   []byte(`{"field":"Zm9vYmFy"}`),
+			expected: []byte(`{"field":"foobar"}`),
+			wantErr:  false,
+		},
+		{
+			name:     "base64decode on empty string",
+			sc:       vaultSecretSyncWithTemplate(`{"field":"{{ .field | base64decode }}"}`),
+			secret:   []byte(`{"field":""}`),
+			expected: []byte(`{"field":""}`),
+			wantErr:  false,
+		},
+		{
+			name:     "base64decode handles unicode string",
+			sc:       vaultSecretSyncWithTemplate(`{"field":"{{ .field | base64decode }}"}`),
+			secret:   []byte(`{"field":"44GT44KT44Gr44Gh44Gv"}`),
+			expected: []byte(`{"field":"こんにちは"}`),
+			wantErr:  false,
+		},
+		{
+			name:     "base64encode preserves padding for single byte",
+			sc:       vaultSecretSyncWithTemplate(`{"field":"{{ .field | base64encode }}"}`),
+			secret:   []byte(`{"field":"f"}`),
+			expected: []byte(`{"field":"Zg=="}`),
+			wantErr:  false,
+		},
+		{
+			name:        "base64decode on number returns error",
+			sc:          vaultSecretSyncWithTemplate(`{"field":"{{ .field | base64decode }}"}`),
+			secret:      []byte(`{"field":42}`),
+			expected:    []byte(`{"field":42}`),
+			wantErr:     true,
+			errContains: "base64decode expects string",
+		},
+		{
+			name:        "base64decode invalid base64 returns error",
+			sc:          vaultSecretSyncWithTemplate(`{"field":"{{ .field | base64decode }}"}`),
+			secret:      []byte(`{"field":"not-valid-base64!"}`),
+			expected:    []byte(`{"field":"not-valid-base64!"}`),
+			wantErr:     true,
+			errContains: "illegal base64 data",
+		},
+		{
+			name:     "base64decode with JSON characters",
+			sc:       vaultSecretSyncWithTemplate(`{"field":{{ .field | base64decode | json }}}`),
+			secret:   []byte(`{"field":"Zm9vImJhcg=="}`),
+			expected: []byte(`{"field":"foo\"bar"}`),
+			wantErr:  false,
+		},
+		{
+			name:     "base64decode JSON construct",
+			sc:       vaultSecretSyncWithTemplate(`{"field":{{ .field | base64decode | json }}}`),
+			secret:   []byte(`{"field":"eyJhIjoiYiJ9"}`),
+			expected: []byte(`{"field":"{\"a\":\"b\"}"}`),
+			wantErr:  false,
+		},
+		{
+			name:     "base64encode then base64decode round trip",
+			sc:       vaultSecretSyncWithTemplate(`{"field":{{ .field | base64encode | base64decode | json }}}`),
+			secret:   []byte(`{"field":"\"foo\"bar\""}`),
+			expected: []byte(`{"field":"\"foo\"bar\""}`),
 			wantErr:  false,
 		},
 	}
@@ -47,6 +233,9 @@ func TestExecuteTransformTemplate(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ExecuteTransformTemplate() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+			if tt.wantErr {
+				assert.ErrorContains(t, err, tt.errContains)
 			}
 			assert.Equal(t, tt.expected, result)
 		})
@@ -267,6 +456,16 @@ func TestExecuteTransforms(t *testing.T) {
 			}
 			assert.Equal(t, tt.expected, result)
 		})
+	}
+}
+
+func vaultSecretSyncWithTemplate(template string) v1alpha1.VaultSecretSync {
+	return v1alpha1.VaultSecretSync{
+		Spec: v1alpha1.VaultSecretSyncSpec{
+			Transforms: &v1alpha1.TransformSpec{
+				Template: ptrToString(template),
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
Hi @robertlestak,

I would like to contribute the `base64encode` and `base64decode` functions since we have a syncing use case that requires base64 encoding. I hope that I have identified all of the corner cases in the tests. I also added some documentation on the new functions.
```yaml
  transforms:
    template: |
      {
        "base64encoded": {{ .password | base64encode | json }},
        "base64decoded": {{ .base64encoded | base64decode | json }}
      }
```

While writing the tests I also came along some behavior that appeared to be unexpected to me. I did not wanted to mess with behavior of existing functions and have instead added tests for theses functions that illustrate the current behavior.
One exception is the `json`  function. It now hands over unmarshalling errors to the outer function. Feel free to revert this change if it's not wanted for whatever reason.

I also added a paragraph to the docs that explains that strings with special JSON chars (`"`, `\`) will not survive the template transformation unless they are sanitized with the `json` function.
```yaml
  transforms:
    template: |
      {
        "cannot_handle_json_chars_in_password": "{{ .password }}", ⚠️
        "safely_escaped_password": {{ .password | json }}          ✅
      }
```